### PR TITLE
Fix DDoSecrets Domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BlueLeaks Explorer
 
-BlueLeaks Explorer is open source software for journalists to investigate all of the data in the [BlueLeaks dataset](https://ddosecrets.com/wiki/BlueLeaks). You must have a copy of the BlueLeaks dataset (250GB to download, 271GB once extracted) in order to use it.
+BlueLeaks Explorer is open source software for journalists to investigate all of the data in the [BlueLeaks dataset](https://ddosecrets.org/wiki/BlueLeaks). You must have a copy of the BlueLeaks dataset (250GB to download, 271GB once extracted) in order to use it.
 
 For in-depth instructions, read Chapter 10 of [Hacks, Leaks, and Revelations](https://hacksandleaks.com/).
 


### PR DESCRIPTION
Closes #101 by updating DDoSecrets domain from `.com` to `.org`. More information about the domain change can be found on the [DDoSecrets BlueSky profile](https://bsky.app/profile/ddosecrets.org/post/3mdlfehxwes2v).