### PR TITLE
Remove obsolete Docker Compose version attribute

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   app:
     build: .


### PR DESCRIPTION
I am submitting this as a draft first. I need to test to verify no breaking changes. This PR would close #103 